### PR TITLE
Update rotating-tor-proxies.cfg

### DIFF
--- a/httpTorBalancer/rotating-tor-proxies.cfg
+++ b/httpTorBalancer/rotating-tor-proxies.cfg
@@ -11,10 +11,9 @@ defaults
 frontend rotatingproxies
         bind localhost:3128
         default_backend tors
-        option http_proxy
+        mode tcp
 
 backend tors
-        option http_proxy
         server tor0 localhost:31000
         server tor1 localhost:31001
         server tor2 localhost:31002


### PR DESCRIPTION
This makes haproxy load balance on the tcp level instead of http